### PR TITLE
Add Linters to Test Suite

### DIFF
--- a/lint_test.go
+++ b/lint_test.go
@@ -1,0 +1,19 @@
+package kiasu
+
+import (
+	"testing"
+
+	"github.com/surullabs/lint"
+)
+
+func TestLint(t *testing.T) {
+	// Run default linters
+	err := lint.Default.Check("./...")
+
+	// Ignore lint errors from auto-generated files
+	err = lint.Skip(err, lint.RegexpMatch(`internal/`, `_string\.go`, `\.pb\.go`))
+
+	if err != nil {
+		t.Fatalf("lint failures: %v\n", err)
+	}
+}


### PR DESCRIPTION
Run the default suite of `https://github.com/surullabs/lint` linters on tests